### PR TITLE
[bugfix] exportImage在自定义组件中失效问题修复

### DIFF
--- a/dist/weapp-qrcode.js
+++ b/dist/weapp-qrcode.js
@@ -414,7 +414,7 @@ var QRCode;
                 console.log(res.tempFilePath)
                 callback(res.tempFilePath)
             }
-        })
+        }, this._htOption.usingIn)
     }
 
     QRCode.CorrectLevel = QRErrorCorrectLevel;


### PR DESCRIPTION
wx.canvasToTempFilePath(Object object, Object this)，在自定义组件中也需要传当前组件的this对象